### PR TITLE
Notes with labels example

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:core:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     // Room
     implementation "androidx.room:room-runtime:$room_version"

--- a/app/src/androidTest/java/com/github/androidpirate/slicknotes/NotesWithLabelsTest.java
+++ b/app/src/androidTest/java/com/github/androidpirate/slicknotes/NotesWithLabelsTest.java
@@ -1,0 +1,103 @@
+/*
+ * <!--
+ *  Copyright (C) 2016 The Android Open Source Project
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ * -->
+ */
+
+package com.github.androidpirate.slicknotes;
+
+import android.content.Context;
+
+import androidx.room.Room;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.github.androidpirate.slicknotes.data.Label;
+import com.github.androidpirate.slicknotes.data.Note;
+import com.github.androidpirate.slicknotes.data.NoteDao;
+import com.github.androidpirate.slicknotes.data.NoteDatabase;
+import com.github.androidpirate.slicknotes.data.NoteLabelCrossRef;
+import com.github.androidpirate.slicknotes.data.NoteWithLabels;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class NotesWithLabelsTest {
+
+    private NoteDatabase db;
+    private NoteDao dao;
+
+    @Before
+    public void createDb() {
+        Context context = ApplicationProvider.getApplicationContext();
+        db = Room.inMemoryDatabaseBuilder(context, NoteDatabase.class).build();
+        dao = db.dao();
+    }
+
+    @After
+    public void closeDb() {
+        db.close();
+    }
+
+    @Test
+    public void writeAndReadNotesWithLabels() throws Exception {
+
+        // create some labels ...
+        Label label1 = new Label("one");
+        Label label2 = new Label("two");
+        Label label3 = new Label("three");
+
+        // ... and save them to the database
+        int label1Id = new Long(dao.insertLabel(label1)).intValue();
+        int label2Id = new Long(dao.insertLabel(label2)).intValue();
+        int label3Id = new Long(dao.insertLabel(label3)).intValue();
+
+        // create some notes ...
+        Note noteA = new Note("Note A", "This is A note.", new Date());
+        Note noteB = new Note("Note B", "This is B note.", new Date());
+
+        // ... and save them to the database
+        int noteAId = new Long(dao.insertDatabaseNote(noteA)).intValue();
+        int noteBId = new Long(dao.insertDatabaseNote(noteB)).intValue();
+
+        // now, we can associate notes with labels:
+        //  noteA with labels "one" and "two"
+        //  noteB with labels "two" and "three"
+        dao.insertNoteLabelCrossRef(new NoteLabelCrossRef(noteAId, label1Id));
+        dao.insertNoteLabelCrossRef(new NoteLabelCrossRef(noteAId, label2Id));
+        dao.insertNoteLabelCrossRef(new NoteLabelCrossRef(noteBId, label2Id));
+        dao.insertNoteLabelCrossRef(new NoteLabelCrossRef(noteBId, label3Id));
+
+        // query for all notes with their labels
+        List<NoteWithLabels> notesWithLabels = dao.getAllNotesWithLabels();
+
+        assertEquals("There should be 2 notes", 2, notesWithLabels.size());
+
+        assertEquals("First note should be Note A", noteAId, notesWithLabels.get(0).getNoteId());
+        assertEquals("First note should have 2 labels", 2, notesWithLabels.get(0).getLabels().size());
+        assertEquals("First note should have label 'one'", label1Id, notesWithLabels.get(0).getLabels().get(0).getLabelId());
+        assertEquals("First note should have label 'two'", label2Id, notesWithLabels.get(0).getLabels().get(1).getLabelId());
+
+        assertEquals("Second note should be Note B", noteBId, notesWithLabels.get(1).getNote().getNoteId());
+        assertEquals("Second note should have 2 labels", 2, notesWithLabels.get(1).getLabels().size());
+        assertEquals("Second note should have label 'two'", label2Id, notesWithLabels.get(1).getLabels().get(0).getLabelId());
+        assertEquals("Second note should have label 'three'", label3Id, notesWithLabels.get(1).getLabels().get(1).getLabelId());
+    }
+}

--- a/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteDao.java
+++ b/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteDao.java
@@ -20,11 +20,13 @@ package com.github.androidpirate.slicknotes.data;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.Query;
+import androidx.room.Transaction;
 import androidx.room.Update;
 
 @Dao
@@ -51,7 +53,7 @@ public interface NoteDao {
     @Query("SELECT * FROM notes WHERE note_pin_status = 1")
     LiveData<List<Note>> getPinnedNotes();
     @Insert
-    void insertDatabaseNote(Note note);
+    long insertDatabaseNote(Note note);
     @Delete
     void deleteDatabaseNote(Note note);
     @Delete
@@ -64,4 +66,15 @@ public interface NoteDao {
     void updateTrashStatus(int noteId, boolean isTrash);
     @Query("UPDATE notes SET note_pin_status = :pinStatus WHERE noteId = :noteId")
     void updatePinStatus(int noteId, boolean pinStatus);
+
+    @Insert
+    long insertLabel(@NonNull Label label);
+
+    @Insert
+    void insertNoteLabelCrossRef(@NonNull NoteLabelCrossRef noteLabelRef);
+
+    @NonNull
+    @Transaction
+    @Query("SELECT * FROM notes ORDER BY note_title")
+    List<NoteWithLabels> getAllNotesWithLabels();
 }

--- a/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteDatabase.java
+++ b/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteDatabase.java
@@ -34,7 +34,7 @@ import androidx.room.TypeConverters;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
 // TODO 2: New entities, Label and NoteLabelCrossRef are added into database
-@Database(entities = {Note.class, Label.class, NoteLabelCrossRef.class}, version = 1, exportSchema = false)
+@Database(entities = {Note.class, Label.class, NoteLabelCrossRef.class}, version = 2, exportSchema = false)
 @TypeConverters({Converters.class})
 public abstract class NoteDatabase extends RoomDatabase {
     private static NoteDatabase INSTANCE;
@@ -59,6 +59,8 @@ public abstract class NoteDatabase extends RoomDatabase {
                             });
                         }
                     })
+                    // TODO create real migrations, don't publish with this option
+                    .fallbackToDestructiveMigration()
                     .build();
         }
         return INSTANCE;

--- a/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteLabelCrossRef.java
+++ b/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteLabelCrossRef.java
@@ -25,6 +25,11 @@ public class NoteLabelCrossRef {
     private int noteId;
     private int labelId;
 
+    public NoteLabelCrossRef(int noteId, int labelId) {
+        this.noteId = noteId;
+        this.labelId = labelId;
+    }
+
     public int getNoteId() {
         return noteId;
     }

--- a/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteWithLabels.java
+++ b/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteWithLabels.java
@@ -43,7 +43,7 @@ public class NoteWithLabels {
         return note;
     }
 
-    public int getNoteId() {
+    public long getNoteId() {
         return note.getNoteId();
     }
 

--- a/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteWithLabels.java
+++ b/app/src/main/java/com/github/androidpirate/slicknotes/data/NoteWithLabels.java
@@ -43,7 +43,7 @@ public class NoteWithLabels {
         return note;
     }
 
-    public long getNoteId() {
+    public int getNoteId() {
         return note.getNoteId();
     }
 


### PR DESCRIPTION
#1 

Here is an example of associating `Note`s with `Label`s and then querying for those notes with their labels as `NoteWithLabels` objects.  See the code in the Android test class I created that creates some labels and notes, then associates them with each other and then queries for their relationships.

You need to insert the associations into the `NoteLabelCrossRef` table once you know the IDs of the notes and labels you want to associate.

To query, you only need to specify a select from the "parent" table, in this case it's the `@Embedded` `Note` object.  The `@Relation` annotation on the list of `Label`s makes Room execute a subquery to get the labels for each note returned from the main query.  This is also why you should put a `@Transaction` annotation on the DAO method, since it executes more than one query and should be executed in a transaction.